### PR TITLE
Import Gamepad class from __init__.py

### DIFF
--- a/gamepad/__init__.py
+++ b/gamepad/__init__.py
@@ -5,3 +5,9 @@
 __author__ = """Darius Montez"""
 __email__ = 'darius.montez@gmail.com'
 __version__ = '0.1.0'
+
+from gamepad.gamepad import Gamepad
+
+__all__ = [
+    'Gamepad'
+]

--- a/gamepad/cli.py
+++ b/gamepad/cli.py
@@ -4,7 +4,7 @@
 import sys
 import click
 
-from gamepad.gamepad import Gamepad
+from gamepad import Gamepad
 
 
 @click.command()

--- a/tests/test_gamepad.py
+++ b/tests/test_gamepad.py
@@ -7,7 +7,7 @@ import pytest
 
 from click.testing import CliRunner
 
-# from gamepad.gamepad import Gamepad
+# from gamepad import Gamepad
 from gamepad import cli
 
 


### PR DESCRIPTION
Importing `Gamepad` in `__init__.py` allows it to be used easier, like this:

```python
from gamepad import Gamepad
```

Instead of like this:

```python
from gamepad.gamepad import Gamepad
```